### PR TITLE
adding project.clj and fixing type problem

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,0 +1,7 @@
+(defproject tools.analyzer.clr "0.1.0-SNAPSHOT"
+  :description "FIXME: write description"
+  :url "http://example.com/FIXME"
+  :license {:name "Eclipse Public License"
+            :url "http://www.eclipse.org/legal/epl-v10.html"}
+  :dependencies [;;[org.clojure/clojure "1.8.0"]
+                 ])

--- a/src/clojure/tools/analyzer/clr/analyze_host_forms.clj
+++ b/src/clojure/tools/analyzer/clr/analyze_host_forms.clj
@@ -4,7 +4,8 @@
     [uniquify :refer [uniquify-locals]]]
    [clojure.tools.analyzer.clr
     [errors :refer [error] :as errors]
-    [types :refer [read-generic-name clr-type class-for-name best-match]]]))
+    [types :refer [read-generic-name clr-type class-for-name best-match]]])
+  (:import [System.Reflection BindingFlags]))
 
 (def public-instance (enum-or BindingFlags/Instance BindingFlags/Public))
 (def public-static (enum-or BindingFlags/Static BindingFlags/Public))


### PR DESCRIPTION
adds a project.clj (for easier publishing/dependency management down the line), and fixes a type qualification problem in src/clojure/tools/analyzer/clr/analyze_host_forms.clj